### PR TITLE
Remove empty tuples from a list

### DIFF
--- a/Contributor/remove_empty_tuples
+++ b/Contributor/remove_empty_tuples
@@ -1,0 +1,14 @@
+# Python program to remove empty tuples from
+# a list of tuples function to remove empty
+# tuples using filter
+
+
+def Remove(tuples):
+	tuples = filter(None, tuples)
+	return tuples
+
+
+# Driver Code
+tuples = [(), ('ram', '15', '8'), (), ('laxman', 'sita'),
+		('krishna', 'akbar', '45'), ('', ''), ()]
+print(Remove(tuples))


### PR DESCRIPTION
Using the inbuilt method filter() in Python, we can filter out the empty elements by passing the None as the parameter. This method works in both Python 2 and Python 3 and above, but the desired output is only shown in Python 2 because Python 3 returns a generator. filter() is faster than the method of list comprehension.